### PR TITLE
Fixes the install path and adds requirements

### DIFF
--- a/climber.py
+++ b/climber.py
@@ -14,7 +14,7 @@ import sys
 import time
 
 # Customizable paths
-INSTALL_PATH = os.path.dirname(__file__)
+INSTALL_PATH = os.path.dirname(os.path.abspath(__file__))
 LOGS_PATH = expanduser('~') + '/climber'
 
 # Terminal colors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Mako==1.0.4
+paramiko==1.16.0
+pycrypto==2.6.1


### PR DESCRIPTION
When running in Mac OSX El Captain there is an error about the variable INSTALL_PATH. I fixed it using the current directory as the install path.
Also, I added a requirements.txt file to simplify the install command.
